### PR TITLE
Fix file outputs getting overwritten

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+data/fake*

--- a/src/main/scala/io/confluent/eventsim/Output.scala
+++ b/src/main/scala/io/confluent/eventsim/Output.scala
@@ -23,7 +23,7 @@ object Output {
   }
 
   private class FileEventWriter(val constructor: events.Constructor, val file: File) extends Object with canwrite {
-    val out = new FileOutputStream(file)
+    val out = new FileOutputStream(file, true)
 
     def write() = out.write(constructor.end().asInstanceOf[Array[Byte]])
 
@@ -82,16 +82,16 @@ object Output {
 
   val authEventWriter =
     if (kbl.isSupplied) new KafkaEventWriter(authConstructor, "auth_events", kbl.get.get)
-    else new FileEventWriter(authConstructor, new File(dirName, "auth_events"))
+    else new FileEventWriter(authConstructor, new File(dirName, "auth_events.json"))
   val listenEventWriter =
     if (kbl.isSupplied) new KafkaEventWriter(listenConstructor, "listen_events", kbl.get.get)
-    else new FileEventWriter(listenConstructor, new File(dirName, "listen_events"))
+    else new FileEventWriter(listenConstructor, new File(dirName, "listen_events.json"))
   val pageViewEventWriter =
     if (kbl.isSupplied) new KafkaEventWriter(pageViewConstructor, "page_view_events", kbl.get.get)
-    else new FileEventWriter(pageViewConstructor, new File(dirName, "page_view_events"))
+    else new FileEventWriter(pageViewConstructor, new File(dirName, "page_view_events.json"))
   val statusChangeEventWriter =
     if (kbl.isSupplied) new KafkaEventWriter(statusChangeConstructor, "status_change_events", kbl.get.get)
-    else new FileEventWriter(statusChangeConstructor, new File(dirName, "status_change_events"))
+    else new FileEventWriter(statusChangeConstructor, new File(dirName, "status_change_events.json"))
 
   def flushAndClose(): Unit = {
     authEventWriter.flushAndClose()


### PR DESCRIPTION
# Description
Fixes the bug of `FileEventWriter` overwriting the contents each time it wrote to an output file. This bug resulted in the outputs being only 0-1 KB even when simulating a million users for an hour. After the fix, the output file will be larger and contain the events throughout the entire hour.

# Testing
1. Build the docker image.
2. Run a container using  (assuming the image name is `eventsim`): 
```
docker run -it \
            -v  <path_to_project_root>/data:/opt/eventsim/data \
            -v  <path_to_project_root>/examples:/opt/eventsim/examples \
            eventsim \
              -c "examples/example-config.json" \
              --nusers 10000 \
              --start-time "`date +"%Y-%m-%dT%H:%M:%S"`" \
              --end-time "`date -d "+1 hour" +"%Y-%m-%dT%H:%M:%S"`" \
              data/outputs
```
3. Check that the `data/outputs` folder has 4 json files. The `listen_events` and `page_view_events` files should be 10's of MB in size, while the `auth_events` and `status_change_events` are smaller.
