### PR TITLE
Add feature to write new files daily

### DIFF
--- a/src/main/scala/io/confluent/eventsim/Output.scala
+++ b/src/main/scala/io/confluent/eventsim/Output.scala
@@ -80,16 +80,16 @@ object Output {
   if (!dirName.exists())
     dirName.mkdir()
 
-  val authEventWriter =
+  var authEventWriter =
     if (kbl.isSupplied) new KafkaEventWriter(authConstructor, "auth_events", kbl.get.get)
     else new FileEventWriter(authConstructor, new File(dirName, "auth_events.json"))
-  val listenEventWriter =
+  var listenEventWriter =
     if (kbl.isSupplied) new KafkaEventWriter(listenConstructor, "listen_events", kbl.get.get)
     else new FileEventWriter(listenConstructor, new File(dirName, "listen_events.json"))
-  val pageViewEventWriter =
+  var pageViewEventWriter =
     if (kbl.isSupplied) new KafkaEventWriter(pageViewConstructor, "page_view_events", kbl.get.get)
     else new FileEventWriter(pageViewConstructor, new File(dirName, "page_view_events.json"))
-  val statusChangeEventWriter =
+  var statusChangeEventWriter =
     if (kbl.isSupplied) new KafkaEventWriter(statusChangeConstructor, "status_change_events", kbl.get.get)
     else new FileEventWriter(statusChangeConstructor, new File(dirName, "status_change_events.json"))
 
@@ -178,5 +178,12 @@ object Output {
     }
 
     pageViewEventWriter.write
+  }
+
+  def setFileSuffix(fileSuffix: String): Unit = {
+    authEventWriter = new FileEventWriter(authConstructor, new File(dirName, "auth_events" + fileSuffix + ".json"))
+    listenEventWriter = new FileEventWriter(listenConstructor, new File(dirName, "listen_events" + fileSuffix + ".json"))
+    pageViewEventWriter = new FileEventWriter(pageViewConstructor, new File(dirName, "page_view_events" + fileSuffix + ".json"))
+    statusChangeEventWriter = new FileEventWriter(statusChangeConstructor, new File(dirName, "status_change_events" + fileSuffix + ".json"))
   }
 }

--- a/src/main/scala/io/confluent/eventsim/TimeUtilities.scala
+++ b/src/main/scala/io/confluent/eventsim/TimeUtilities.scala
@@ -3,7 +3,7 @@ package io.confluent.eventsim
 import java.time.temporal.{ChronoField, ChronoUnit}
 import java.time.{DayOfWeek, Duration, LocalDate, LocalDateTime}
 
-import de.jollyday.HolidayManager
+import de.jollyday.{HolidayManager, ManagerParameters, HolidayCalendar}
 import io.confluent.eventsim.Constants._
 import io.confluent.eventsim.config.ConfigFromFile
 import org.apache.commons.math3.random.MersenneTwister
@@ -13,7 +13,7 @@ object TimeUtilities {
   // def dateTimeToLocalDate(dt: Instant): LocalDate = LocalDate.from(Instant.ofEpochMilli(dt.getMillis()))
 
   // first implementation: US only
-  val holidays = HolidayManager.getInstance()
+  val holidays = HolidayManager.getInstance(ManagerParameters.create(HolidayCalendar.UNITED_STATES))
 
   def isHoliday(ld: LocalDate): Boolean = holidays.isHoliday(ld)
 


### PR DESCRIPTION
# Description
Adds a feature for FileEventWriter to output a new set of files for each day's events.

# Testing
1. Build the docker image.
2. Run a container using (assuming the image name is eventsim):
```
docker run -it \
            -v  <path_to_project_root>/data:/opt/eventsim/data \
            -v  <path_to_project_root>/examples:/opt/eventsim/examples \
            eventsim \
              -c "examples/example-config.json" \
              --nusers 10000 \
              --start-time "`date +"%Y-%m-%dT%H:%M:%S"`" \
              --end-time "`date -d "+3 days" +"%Y-%m-%dT%H:%M:%S"`" \
              --nocontinuous \
              data/outputs
```
3. Check that the `data/outputs` folder has 12 (= 4 files per day * 3 days) json files. 